### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/MaxProvin/story-box.png?label=ready&title=Ready)](https://waffle.io/MaxProvin/story-box)
 [![Build Status](https://travis-ci.org/MaxProvin/story-box.svg?branch=master)](https://travis-ci.org/MaxProvin/story-box)
 [![Coverage Status](https://coveralls.io/repos/github/MaxProvin/story-box/badge.svg?branch=master)](https://coveralls.io/github/MaxProvin/story-box?branch=master)
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/MaxProvin/story-box

This was requested by a real person (user MaxProvin) on waffle.io, we're not trying to spam you.
